### PR TITLE
Add license to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "prolic/fpp",
   "description": "Functional PHP Preprocessor",
+  "license": "BSD-3-Clause",
   "authors": [
     {
       "name": "Sascha-Oliver Prolic",


### PR DESCRIPTION
Thank you for the great package.

I want to use it in my project. The problem is that we use [metasyntactical/composer-plugin-license-check](https://packagist.org/packages/metasyntactical/composer-plugin-license-check) to check packages license against the whitelist. Since the `license` is not in the `composer.json`, it fails composer install.
 
Thank you in advance. 