### PR TITLE
Remove redundant check in ToArray generated body

### DIFF
--- a/src/builder/buildToArrayBody.php
+++ b/src/builder/buildToArrayBody.php
@@ -50,12 +50,6 @@ function buildToArrayBody(Definition $definition, ?Constructor $constructor, Def
     $class .= $definition->name();
 
     foreach ($constructor->arguments() as $key => $argument) {
-        if ($argument->nullable() && $argument->isScalartypeHint()) {
-            $code .= "            '{$argument->name()}' => ";
-            $code .= "null === \$this->{$argument->name()} ? null : \$this->{$argument->name()},\n";
-            continue;
-        }
-
         if ($argument->isScalartypeHint() && ! $argument->isList()) {
             $code .= "            '{$argument->name()}' => ";
             $code .= "\$this->{$argument->name()},\n";

--- a/tests/Builder/BuildToArrayBodyTest.php
+++ b/tests/Builder/BuildToArrayBodyTest.php
@@ -75,7 +75,7 @@ class BuildToArrayBodyTest extends TestCase
 
         return [
             'id' => \$this->id->toString(),
-            'name' => null === \$this->name ? null : \$this->name,
+            'name' => \$this->name,
             'email' => \$this->email->toString(),
             'secondaryEmails' => \$secondaryEmails,
             'nickNames' => \$this->nickNames,


### PR DESCRIPTION
Part of #29.

If a variable can only be a `scalar` or `null`, then `null === \$var ? null : \$var` is equivalent to `$var`. So we remove the redundant check.