### PR TITLE
Use null comparisons instead of isset() on class properties

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -200,9 +200,9 @@ function buildMethodBodyFromPayload(Argument $argument, Definition $definition, 
     $argumentName = $argument->name();
 
     if ($withCache && $argument->nullable()) {
-        $check = "if (! isset(\$this->$argumentName) && isset(\$this->payload['$argumentName'])) {";
+        $check = "if (null === \$this->$argumentName && isset(\$this->payload['$argumentName'])) {";
     } elseif ($withCache && ! $argument->nullable()) {
-        $check = "if (! isset(\$this->$argumentName)) {";
+        $check = "if (null === \$this->$argumentName) {";
     }
 
     if ($argument->isScalartypeHint() || null === $argument->type()) {
@@ -360,7 +360,7 @@ function buildMethodBodyFromAggregateId(Argument $argument, Definition $definiti
     if ($argument->isScalartypeHint() || null === $argument->type()) {
         if ($withCache) {
             return <<<CODE
-if (! isset(\$this->$argumentName)) {
+if (null === \$this->$argumentName) {
             \$this->$argumentName = \$this->aggregateId();
         }
 
@@ -400,7 +400,7 @@ CODE;
             case Deriving\Uuid::VALUE:
                 if ($withCache) {
                     return <<<CODE
-if (! isset(\$this->$argumentName)) {
+if (null === \$this->$argumentName) {
             \$this->$argumentName = $calledClass::fromString(\$this->aggregateId());
         }
 
@@ -412,7 +412,7 @@ CODE;
             case Deriving\FromScalar::VALUE:
                 if ($withCache) {
                     return <<<CODE
-if (! isset(\$this->$argumentName)) {
+if (null === \$this->$argumentName) {
             \$this->$argumentName = $calledClass::fromScalar(\$this->aggregateId());
         }
 

--- a/tests/Builder/BuildAccessorsTest.php
+++ b/tests/Builder/BuildAccessorsTest.php
@@ -71,7 +71,7 @@ STRING;
         $expected = <<<STRING
 public function name(): string
     {
-        if (! isset(\$this->name)) {
+        if (null === \$this->name) {
             \$this->name = \$this->aggregateId();
         }
 
@@ -80,7 +80,7 @@ public function name(): string
 
     public function age(): ?int
     {
-        if (! isset(\$this->age) && isset(\$this->payload['age'])) {
+        if (null === \$this->age && isset(\$this->payload['age'])) {
             \$this->age = \$this->payload['age'];
         }
 
@@ -89,7 +89,7 @@ public function name(): string
 
     public function whatever()
     {
-        if (! isset(\$this->whatever)) {
+        if (null === \$this->whatever) {
             \$this->whatever = \$this->payload['whatever'];
         }
 

--- a/tests/Builder/BuildMethodBodyFromAggregateIdTest.php
+++ b/tests/Builder/BuildMethodBodyFromAggregateIdTest.php
@@ -143,7 +143,7 @@ class BuildMethodBodyFromAggregateIdTest extends TestCase
         $collection = new DefinitionCollection($definition1, $definition2);
 
         $expected = <<<CODE
-if (! isset(\$this->name)) {
+if (null === \$this->name) {
             \$this->name = Arg::fromString(\$this->aggregateId());
         }
 

--- a/tests/Builder/BuildMethodBodyFromPayloadTest.php
+++ b/tests/Builder/BuildMethodBodyFromPayloadTest.php
@@ -195,7 +195,7 @@ class BuildMethodBodyFromPayloadTest extends TestCase
         $collection = new DefinitionCollection($definition1, $definition2);
 
         $expected = <<<CODE
-if (! isset(\$this->name) && isset(\$this->payload['name'])) {
+if (null === \$this->name && isset(\$this->payload['name'])) {
             \$__returnValue = [];
 
             foreach (\$this->payload['name'] as \$__value) {
@@ -281,7 +281,7 @@ CODE;
         $collection = new DefinitionCollection($definition1, $definition2);
 
         $expected = <<<CODE
-if (! isset(\$this->name)) {
+if (null === \$this->name) {
             \$__returnValue = [];
 
             foreach (\$this->payload['name'] as \$__value) {
@@ -363,7 +363,7 @@ CODE;
         $collection = new DefinitionCollection($definition1, $definition2);
 
         $expected = <<<CODE
-if (! isset(\$this->name) && isset(\$this->payload['name'])) {
+if (null === \$this->name && isset(\$this->payload['name'])) {
             \$this->name = isset(\$this->payload['name']) ? Arg::fromString(\$this->payload['name']) : null;
         }
 
@@ -431,7 +431,7 @@ CODE;
         $collection = new DefinitionCollection($definition1, $definition2);
 
         $expected = <<<CODE
-if (! isset(\$this->name)) {
+if (null === \$this->name) {
             \$this->name = Arg::fromString(\$this->payload['name']);
         }
 


### PR DESCRIPTION
Part of #29.

It feels weird to have `isset()` check on a class' property since they are declared in the class. `null ===` is more natural IMHO. PhpStorm even displays a warning for this.