### PR TITLE
[WIP] Define domain exceptions and use them inside constructor conditions 

### DIFF
--- a/src/Deriving/Exception.php
+++ b/src/Deriving/Exception.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of prolic/fpp.
+ * (c) 2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Fpp\Deriving;
+
+use Fpp\Definition;
+
+class Exception extends AbstractDeriving
+{
+    public const VALUE = 'Exception';
+
+    private $parentClass;
+
+    public function __construct(string $parentClass = '\Exception')
+    {
+        $this->parentClass = $parentClass;
+    }
+
+    public function parentClass(): string
+    {
+        return $this->parentClass;
+    }
+
+    public function checkDefinition(Definition $definition): void
+    {
+    }
+
+    private function forbidsDerivings(): array
+    {
+        return [
+            AggregateChanged::VALUE,
+            Command::VALUE,
+            DomainEvent::VALUE,
+            Query::VALUE,
+            MicroAggregateChanged::VALUE,
+            ToArray::VALUE,
+            ToScalar::VALUE,
+            ToString::VALUE,
+            Uuid::VALUE,
+        ];
+    }
+}

--- a/src/builder/buildClassExtends.php
+++ b/src/builder/buildClassExtends.php
@@ -41,6 +41,10 @@ function buildClassExtends(Definition $definition, ?Constructor $constructor, De
         if ($deriving->equals(new Deriving\MicroAggregateChanged())) {
             return ' extends \Prooph\Common\Messaging\DomainEvent';
         }
+
+        if ($deriving->equals(new Deriving\Exception())) {
+            return sprintf(' extends %s', $deriving->parentClass());
+        }
     }
 
     $fullQualifiedDefinitionClassName = $definition->name();

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -1091,6 +1091,44 @@ CODE;
         $this->assertSame(['foo' => 'bar', 'baz', 1, true, 'bam' => 123], $deriving->valueMapping()['Yellow']);
     }
 
+    /**
+     * @test
+     */
+    public function it_parses_exception_using_base_exception_class()
+    {
+        $contents = <<<CODE
+namespace Something {
+    exception DomainException;
+}
+CODE;
+        $collection = parse($this->createDefaultFile($contents), $this->derivingMap);
+
+        $definition = $collection->definition('Something', 'DomainException');
+
+        $this->assertSame('Something\\DomainException', $definition->constructors()[0]->name());
+        $this->assertInstanceOf(Deriving\Exception::class, $definition->derivings()[0]);
+        $this->assertSame('\\Exception', $definition->derivings()[0]->parentClass());
+    }
+
+    /**
+     * @test
+     */
+    public function it_parses_exception_using_provided_exception_class()
+    {
+        $contents = <<<CODE
+namespace Something {
+    exception DomainException = \InvalidArgumentException;
+}
+CODE;
+        $collection = parse($this->createDefaultFile($contents), $this->derivingMap);
+
+        $definition = $collection->definition('Something', 'DomainException');
+
+        $this->assertSame('Something\\DomainException', $definition->constructors()[0]->name());
+        $this->assertInstanceOf(Deriving\Exception::class, $definition->derivings()[0]);
+        $this->assertSame('\\InvalidArgumentException', $definition->derivings()[0]->parentClass());
+    }
+
     public function scalarListTypes(): array
     {
         return [


### PR DESCRIPTION
# Issue
https://github.com/prolic/fpp/issues/55

# TODO

- [ ] Ensure this is a good idea
- [x] `exception TooShortFirstName` parsing
- [x] `exception TooShortFirstName = \InvalidArgumentException` parsing
- [ ] `where` clause specifying exception classname
- [ ] Parser optimisation
- [ ] Ensure great UT coverage
- [ ] Handle case where parent exception class is not an instance of `\Exception`
- [ ] Handle case where parent exception class simply does not exist
- [ ] Allow defining exception message when use in `where` clause (and a default one?)
- [ ] Allow defining exception named constructors (with additional arguments)
- [ ] Agree on syntax

# Syntax

## Basic usage
```
exception UserNotFound;
```

generates

```php
class UserNotFound extends \Exception
{
}
```

## Custom parent class
```
exception UserNotFound : \RuntimeException;
```

generates

```php
class UserNotFound extends \RuntimeException
{
}
```

## Namespace

```
namespace App\Subscription;
exception UserNotFound : \RuntimeException;
```

generates

```php
namespace App\Subscription;

class UserNotFound extends \RuntimeException
{
}
```

## Named constructors
```
namespace App\Subscription;
data UserId = String deriving (Uuid);
exception UserNotFound : \RuntimeException with
    | withId { UserId $userId } => 'A user with id {{$userId}} was not found'
    | withEmail { string $email } => 'A user with email {{$email}} was not found';
```

generates

```php
namespace App\Subscription;

class UserNotFound extends \RuntimeException
{
    public static function withId(UserId $userId, int $code = 0, \Throwable $previous = null): self
    {
        return new self(sprintf('A user with id %s was not found', $userId->toString()), $code, $previous);
    }

    public static function withEmail(string $email, int $code = 0, \Throwable $previous = null): self
    {
        return new self(sprintf('A user with email %s was not found', $email), $code, $previous);
    }
}
```

## Default message
```
namespace App\Subscription;
exception UserNotFound : \RuntimeException with
    | _ => 'User not found';
```

generates

```php
namespace App\Subscription;

class UserNotFound extends \RuntimeException
{
    public function __construct(string $message = 'User not found', int $code = 0, \Throwable $previous = null): self
    {
        parent::__construct($message, $code, $previous);
    }
}
```

## Usage within conditional constructor
### Named constructor
```
data Age = Int deriving (ToScalar, FromScalar);
exception TooYoung : \InvalidArgumentException with
    | withAge { Age $age } => '{{$age}} is too young.';
data Person = Person { Age $age } where
    Person:
        | $age->toScalar() < 18 => TooYoung::withAge($age);
```

### Default constructor
```
data Age = Int deriving (ToScalar, FromScalar);
exception TooYoung : \InvalidArgumentException;
data Person = Person { Age $age } where
    Person:
        | $age->toScalar() < 18 => TooYoung('{{$age}} is too young.');
```