### PR TITLE
Fixed default value is not set when is zero.

### DIFF
--- a/src/builder/buildArguments.php
+++ b/src/builder/buildArguments.php
@@ -29,7 +29,7 @@ function buildArguments(Definition $definition, ?Constructor $constructor, Defin
         if (null === $argument->type()) {
             $argumentList .= '$' . $argument->name();
 
-            if ($argument->defaultValue()) {
+            if (null !== $argument->defaultValue()) {
                 $argumentList .= ' = ' . $argument->defaultValue();
             }
 
@@ -46,7 +46,7 @@ function buildArguments(Definition $definition, ?Constructor $constructor, Defin
             $argumentType = $argument->isList() ? $argument->type() . ' ...' : $argument->type() . ' ';
             $argumentList .= $argumentType . '$' . $argument->name();
 
-            if ($argument->defaultValue()) {
+            if (null !== $argument->defaultValue()) {
                 $argumentList .= ' = ' . $argument->defaultValue();
             }
 
@@ -56,7 +56,7 @@ function buildArguments(Definition $definition, ?Constructor $constructor, Defin
             $argumentType = $argument->isList() ? 'array' : $argument->type();
             $argumentList .= $argumentType . ' $' . $argument->name();
 
-            if ($argument->defaultValue()) {
+            if (null !== $argument->defaultValue()) {
                 $argumentList .= ' = ' . $argument->defaultValue();
             }
 
@@ -80,7 +80,7 @@ function buildArguments(Definition $definition, ?Constructor $constructor, Defin
         } else {
             $argumentList .= $type . ' $' . $argument->name();
 
-            if ($argument->defaultValue()) {
+            if (null !== $argument->defaultValue()) {
                 $argumentList .= ' = ' . $argument->defaultValue();
             }
 

--- a/tests/Builder/BuildArgumentsTest.php
+++ b/tests/Builder/BuildArgumentsTest.php
@@ -51,7 +51,7 @@ class BuildArgumentsTest extends TestCase
     {
         $constructor = new Constructor('Foo\Bar', [
             new Argument('name', 'string', false, false, '\'test\''),
-            new Argument('value', 'int', false, false, 5),
+            new Argument('value', 'int', false, false, '0'),
             new Argument('value2', null, false, false, '\'test2\''),
         ]);
 
@@ -62,7 +62,7 @@ class BuildArgumentsTest extends TestCase
             [$constructor]
         );
 
-        $expected = 'string $name = \'test\', int $value = 5, $value2 = \'test2\'';
+        $expected = 'string $name = \'test\', int $value = 0, $value2 = \'test2\'';
         $this->assertSame($expected, buildArguments($definition, $constructor, new DefinitionCollection(), ''));
     }
 }


### PR DESCRIPTION
Default value faults in this situation:

```
data Foo = Foo { int $zero = 0, $default = 0 };
```

I saw that default arguments is passed like a string, but `'0'` is casted as `false`. So, in `buildArguments` function is like hasn't a default value.

I changed the test to use zero instead five too.