### PR TITLE
Added check that data definition actually ends with a semicolon.

### DIFF
--- a/src/parse.php
+++ b/src/parse.php
@@ -638,6 +638,9 @@ function parse(string $filename, array $derivingMap): DefinitionCollection
                 if (null === $definitionType) {
                     throw ParseError::unknownDefinitionType($namespace, $name);
                 }
+                if (';' !== $token[1]) {
+                    throw ParseError::unexpectedTokenFound(';', $token, $filename);
+                }
 
                 $collection->addDefinition(new Definition($definitionType, $namespace, $name, $constructors, $derivings, $conditions, $messageName, $markers));
                 break;

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -1193,6 +1193,7 @@ CODE;
         $this->expectException(ParseError::class);
 
         $contents = <<<CODE
+namespace Foo;
 data Foo = Foo SOME_NONSENSE_TOKEN
 CODE;
 

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -1185,6 +1185,20 @@ CODE;
         $this->assertSame('MyMarkerB', (string) $definition->markers()[1]);
     }
 
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_data_definition_does_not_end_in_semicolon(): void
+    {
+        $this->expectException(ParseError::class);
+
+        $contents = <<<CODE
+data Foo = Foo SOME_NONSENSE_TOKEN
+CODE;
+
+        parse($this->createDefaultFile($contents), $this->derivingMap);
+    }
+
     public function scalarListTypes(): array
     {
         return [


### PR DESCRIPTION
With this commit, fpp will check that a data definition ends with a semicolon and not some other token.
For instance, the following code will no longer be accepted:
```
   data Example = Example {
       string $someText
   } THIS_SHOULD_NOT_BE_HERE_BUT_PARSES_JUST_FINE
```
In particular I had an issue where I had forgotten the semicolon and I got a very confusing error message.
```
namespace someNamespace {
  data Example1 = Example1 {
    string $someText
  }
}
namespace someOtherNamespace {
  data Example2 = Example2 {
    string $someText
  };
}

```
Without this pull request, the above example gives a confusing error.
The parser parses the closing bracket for someNamespace instead of the semicolon for the data definition of Example1. It then throws an exception when trying to parse the next namespace definition. It believes the previous definition has not ended and that we are trying to nest namespaces.
With this pull request it would instead throw an exception about the actual problem (the semicolon is missing).
