### PR TITLE
[WIP] Returns nullable arrays as null in toArray.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .php_cs.cache
 nbproject
 composer.lock
+/tests/Fixtures/Generated

--- a/.php_cs
+++ b/.php_cs
@@ -1,7 +1,9 @@
 <?php
 
 $config = new Prooph\CS\Config\Prooph();
-$config->getFinder()->in(__DIR__);
+$config->getFinder()
+    ->exclude('Generated')
+    ->in(__DIR__);
 
 $cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "phpunit/phpunit": "^7.0",
     "prooph/php-cs-fixer-config": "^0.3",
     "satooshi/php-coveralls": "^2.0",
-    "phpstan/phpstan": "^0.10.1"
+    "phpstan/phpstan": "^0.10.1",
+    "ramsey/uuid": "^3.8"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         bootstrap="src/bootstrap.php"
+         bootstrap="tests/bootstrap.php"
 >
     <testsuite name="Fpp Test Suite">
         <directory>./tests</directory>

--- a/src/builder/buildToArrayBody.php
+++ b/src/builder/buildToArrayBody.php
@@ -59,11 +59,11 @@ function buildToArrayBody(Definition $definition, ?Constructor $constructor, Def
 
         if ($argument->isList()) {
             $argumentName = $argument->name();
+            $indent = '';
 
             if ($argument->nullable()) {
-                $prefixCode .= "        if (null === \$this->$argumentName) {\n";
-                $prefixCode .= "            return null;\n";
-                $prefixCode .= "        }\n\n";
+                $prefixCode .= "        if (null !== \$this->$argumentName) {\n";
+                $indent = '    ';
             }
 
             if (null !== $argument->type() && ! $argument->isScalartypeHint()) {
@@ -80,29 +80,29 @@ function buildToArrayBody(Definition $definition, ?Constructor $constructor, Def
                     throw new \RuntimeException("Cannot build ToArray for $class, no argument type hint for {$argument->type()} given");
                 }
 
-                $prefixCode .= "        \${$argumentName} = [];\n\n";
-                $prefixCode .= "        foreach (\$this->$argumentName as \$__value) {\n";
+                $prefixCode .= "$indent        \${$argumentName} = [];\n\n";
+                $prefixCode .= "$indent        foreach (\$this->$argumentName as \$__value) {\n";
 
                 $match = false;
 
                 foreach ($argumentDefinition->derivings() as $deriving) {
                     switch (true) {
                         case $deriving instanceof Deriving\ToArray:
-                            $prefixCode .= "            \${$argumentName}[] = \$__value->toArray();\n";
+                            $prefixCode .= "$indent            \${$argumentName}[] = \$__value->toArray();\n";
                             $match = true;
                             break;
                         case $deriving instanceof Deriving\ToScalar:
-                            $prefixCode .= "            \${$argumentName}[] = \$__value->toScalar();\n";
+                            $prefixCode .= "$indent            \${$argumentName}[] = \$__value->toScalar();\n";
                             $match = true;
                             break;
                         case $deriving instanceof Deriving\Enum:
                             $asWhat = $deriving->useValue() ? 'value' : 'name';
-                            $prefixCode .= "            \${$argumentName}[] = \$__value->{$asWhat}();\n";
+                            $prefixCode .= "$indent            \${$argumentName}[] = \$__value->{$asWhat}();\n";
                             $match = true;
                             break;
                         case $deriving instanceof Deriving\ToString:
                         case $deriving instanceof Deriving\Uuid:
-                            $prefixCode .= "            \${$argumentName}[] = \$__value->toString();\n";
+                            $prefixCode .= "$indent            \${$argumentName}[] = \$__value->toString();\n";
                             $match = true;
                             break;
                     }
@@ -116,7 +116,14 @@ function buildToArrayBody(Definition $definition, ?Constructor $constructor, Def
                     ));
                 }
 
+                if ($argument->nullable()) {
+                    $prefixCode .= "            }\n";
+                    $prefixCode .= "        } else {\n";
+                    $prefixCode .= "            \${$argumentName} = null;\n";
+                }
+
                 $prefixCode .= "        }\n\n";
+
                 $code .= "            '{$argumentName}' => \${$argumentName},\n";
             } else {
                 $code .= "            '{$argumentName}' => \$this->{$argumentName},\n";

--- a/tests/Builder/BuildToArrayBodyTest.php
+++ b/tests/Builder/BuildToArrayBodyTest.php
@@ -53,12 +53,26 @@ class BuildToArrayBodyTest extends TestCase
             ]
         );
 
+        $phoneNumber = new Definition(
+            DefinitionType::data(),
+            'Some',
+            'PhoneNumber',
+            [
+                new Constructor('String'),
+            ],
+            [
+                new Deriving\FromString(),
+                new Deriving\ToString(),
+            ]
+        );
+
         $constructor = new Constructor('My\Person', [
             new Argument('id', 'My\UserId'),
             new Argument('name', 'string', true),
             new Argument('email', 'Some\Email'),
             new Argument('secondaryEmails', 'Some\Email', false, true),
             new Argument('nickNames', 'string', false, true),
+            new Argument('phoneNumbers', 'Some\PhoneNumber', true, true),
         ]);
 
         $definition = new Definition(
@@ -78,17 +92,28 @@ class BuildToArrayBodyTest extends TestCase
             \$secondaryEmails[] = \$__value->toString();
         }
 
+        if (null !== \$this->phoneNumbers) {
+            \$phoneNumbers = [];
+
+            foreach (\$this->phoneNumbers as \$__value) {
+                \$phoneNumbers[] = \$__value->toString();
+            }
+        } else {
+            \$phoneNumbers = null;
+        }
+
         return [
             'id' => \$this->id->toString(),
             'name' => \$this->name,
             'email' => \$this->email->toString(),
             'secondaryEmails' => \$secondaryEmails,
             'nickNames' => \$this->nickNames,
+            'phoneNumbers' => \$phoneNumbers,
         ];
 
 CODE;
 
-        $this->assertSame($expected, buildToArrayBody($definition, $constructor, new DefinitionCollection($definition, $userId, $email), ''));
+        $this->assertSame($expected, buildToArrayBody($definition, $constructor, new DefinitionCollection($definition, $userId, $email, $phoneNumber), ''));
     }
 
     /**

--- a/tests/Fixtures/to_array.fpp
+++ b/tests/Fixtures/to_array.fpp
@@ -1,0 +1,14 @@
+namespace FppTest\Fixtures\Generated;
+
+data User = User {
+    UserId $id,
+    string $name,
+    Email $email,
+    Email[] $secondaryEmails,
+    string[] $nickNames,
+    ?PhoneNumber[] $phoneNumbers
+} deriving (FromArray, ToArray);
+
+data UserId = UserId deriving ( Uuid );
+data Email = Email { string $email }  deriving ( FromString, ToString );
+data PhoneNumber = PhoneNumber { string $number } deriving ( FromString, ToString );

--- a/tests/ToArrayTest.php
+++ b/tests/ToArrayTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of prolic/fpp.
+ * (c) 2018-2019 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FppTest\Functional;
+
+use FppTest\Fixtures\Generated\Email;
+use FppTest\Fixtures\Generated\PhoneNumber;
+use FppTest\Fixtures\Generated\User;
+use FppTest\Fixtures\Generated\UserId;
+use PHPUnit\Framework\TestCase;
+
+class ToArrayTest extends TestCase
+{
+    /**
+     * @dataProvider get_test_cases
+     */
+    public function test_to_array_returns_an_array(User $user, array $array): void
+    {
+        self::assertEquals($array, $user->toArray());
+    }
+
+    public function get_test_cases(): array
+    {
+        return [
+            'with_phone_number' => [
+                new User(
+                    UserId::fromString('7284e062-7a8b-4b17-b4fa-8c162143475d'),
+                    'foo',
+                    Email::fromString('foo@example.com'),
+                    [],
+                    ['bar'],
+                    [PhoneNumber::fromString('+331234567890')]
+                ),
+                [
+                    'id' => '7284e062-7a8b-4b17-b4fa-8c162143475d',
+                    'name' => 'foo',
+                    'email' => 'foo@example.com',
+                    'secondaryEmails' => [],
+                    'nickNames' => ['bar'],
+                    'phoneNumbers' => ['+331234567890'],
+                ],
+            ],
+            'with_null_object_array' => [
+                new User(
+                    UserId::fromString('7284e062-7a8b-4b17-b4fa-8c162143475d'),
+                    'foo',
+                    Email::fromString('foo@example.com'),
+                    [],
+                    ['bar'],
+                    null
+                ),
+                [
+                    'id' => '7284e062-7a8b-4b17-b4fa-8c162143475d',
+                    'name' => 'foo',
+                    'email' => 'foo@example.com',
+                    'secondaryEmails' => [],
+                    'nickNames' => ['bar'],
+                    'phoneNumbers' => null,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of prolic/fpp.
+ * (c) 2018-2019 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+require_once \dirname(__DIR__).'/src/bootstrap.php';
+
+// This could probably be handled by some clever autoloading
+// but for now, this makes sure the files are created before loading the tests.
+$output = null;
+\exec(
+    'php ' . \dirname(__DIR__) . '/bin/fpp ' . __DIR__ . '/Fixtures/to_array.fpp',
+    $output,
+    $exitCode
+);
+if ($exitCode !== 0) {
+    echo \implode("\n", $output);
+    exit($exitCode);
+}


### PR DESCRIPTION
Currently, a null in any nullable-object-array-typed member of an object would cause toArray() to return null. This is a quite surprising.

With this changes null arrays of objects would be added as null in toArray() output.
