### PR TITLE
Fixed the generated @param annotations of arrays.

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -189,7 +189,7 @@ function buildDocBlockArgumentTypes(array $arguments, string $instance = '', boo
         if ($argument->isList()) {
             $isList = true;
 
-            if ($argument->nullable()) {
+            if (! $argument->nullable()) {
                 $params .= "     * @param $leadingSlash{$type}[] \$$name\n";
             } else {
                 $params .= "     * @param $leadingSlash{$type}[]|null \$$name\n";

--- a/tests/Builder/BuildConstructorTest.php
+++ b/tests/Builder/BuildConstructorTest.php
@@ -76,10 +76,10 @@ class BuildConstructorTest extends TestCase
 /**
      * @param \Foo\Bar\Name \$name
      * @param \Foo\Bar\Age \$age
-     * @param string[]|null \$strings
-     * @param float[]|null \$floats
-     * @param \Foo\Bar\Email[]|null \$emails
-     * @param \Foo\Bar\Hobby[] \$hobbies
+     * @param string[] \$strings
+     * @param float[] \$floats
+     * @param \Foo\Bar\Email[] \$emails
+     * @param \Foo\Bar\Hobby[]|null \$hobbies
      * @param string \$message
      * @param int \$code
      * @param null|\Exception \$previous


### PR DESCRIPTION
Null check was reversed.

I discovered this when I accidentally ran phpstan on the generated files.